### PR TITLE
AVDVP-1285 avoke giant silence gaps when RTP timestamps jump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,9 @@ deps/boost_1_65_0/stage/
 
 *.wav
 *.log
-
+*.o
+*.lo
+*.so.*
 .DS_Store
+*~
+.deps

--- a/docker/dbuild.sh
+++ b/docker/dbuild.sh
@@ -14,9 +14,7 @@ docker run \
 
 docker run -it --rm --name pbuilder \
        --mount type=bind,source="$(pwd)/..",target=/app \
-       foo \
-       /bin/bash -c "cd /app/test ; ../build/pcap_ripper 
-
+       foo /bin/bash
 
 # ./bootstrap.sh && mkdir build && cd $_ && ../configure && make && sudo make install
 


### PR DESCRIPTION
In some circumstances, rtp timestamps appear to get changed to a new timebase without SSRC change.  While this appears clearly illegal, it's been observed in multiple locations.  This code treats these situations as a timebase change rather than a gap needing silence injection.